### PR TITLE
Decoupled settings from messenger

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,13 +36,23 @@ from typing import Union
 
 from google.cloud import bigquery
 
-from messenger import send_slack_message
+from messenger import send_slack_message as send_slack_message_to_channel
 from settings import Settings
 
 
 SETTINGS = Settings()
-CLIENT = bigquery.Client()
 
+def send_slack_message(text: str = None,
+                       blocks: list = None):
+    """Wraps the messenger slack message, adding on a slack channel from settings
+    """
+    send_slack_message_to_channel(
+        channel=SETTINGS.SLACK_CHANNEL,
+        api_token=SETTINGS.SLACK_API_TOKEN,
+        text=text,
+        blocks=blocks
+    )
+    
 
 def get_project_ids() -> list:
     """Gets a list of all project IDs within the billing data from BigQuery.
@@ -594,4 +604,6 @@ def slack_notify() -> None:
 
 
 if __name__ == '__main__':
+    SETTINGS.load_from_environment()
+    CLIENT = bigquery.Client()
     slack_notify()

--- a/messenger.py
+++ b/messenger.py
@@ -15,18 +15,12 @@ import ssl as ssl_lib
 import certifi
 import slack
 
-from settings import Settings
-
-SETTINGS = Settings()
-
-# Client to use whilst the cloud function is alive.
 SSL_CONTEXT = ssl_lib.create_default_context(cafile=certifi.where())
-CLIENT = slack.WebClient(token=SETTINGS.SLACK_API_TOKEN, ssl=SSL_CONTEXT)
 
-
-def send_slack_message(text: str = None,
-                       blocks: list = None,
-                       channel: str = SETTINGS.SLACK_CHANNEL):
+def send_slack_message(channel: str,
+                       api_token: str,
+                       text: str = None,
+                       blocks: list = None):
     """Sends a slack message.
 
     Attributes:
@@ -38,8 +32,11 @@ def send_slack_message(text: str = None,
     if not text and not blocks:
         raise argparse.ArgumentError
 
+    # Client to use whilst the cloud function is alive.
+    client = slack.WebClient(token=api_token, ssl=SSL_CONTEXT)
+
     if text:
-        response = CLIENT.chat_postMessage(channel=channel, text=text)
+        response = client.chat_postMessage(channel=channel, text=text)
     if blocks:
-        response = CLIENT.chat_postMessage(channel=channel, blocks=blocks)
+        response = client.chat_postMessage(channel=channel, blocks=blocks)
     assert response["ok"]

--- a/settings.py
+++ b/settings.py
@@ -45,7 +45,7 @@ class Settings:
     STATUS_WARNING = 'WARNING'
     STATUS_NOMINAL = 'NOMINAL'
 
-    def __init__(self):
+    def load_from_environment(self):
         if 'PROJECT_ID' in os.environ:
             self.PROJECT_ID = os.environ['PROJECT_ID']
         else:


### PR DESCRIPTION
## Purpose

Decoupling settings from the messenger and loading them only on running the script.

## How / Next up

This is still just one step along the way. The settings are referenced globally a bit here and there in the script and I want to remove all the globals because they make testing and reuse very difficult.

This is a first step, allowing tests to run. Next up I'll begin adding in some tests and then bit by bit removing the use of global `SETTINGS` and `CLIENT` instances